### PR TITLE
Bugfix 13 extra-period typo in grib_dir_full

### DIFF
--- a/setup_wps_wrf.py
+++ b/setup_wps_wrf.py
@@ -270,7 +270,7 @@ def main(cycle_dt_str_beg, cycle_dt_str_end, cycle_int_h, sim_hrs, icbc_fc_dt, e
         elif icbc_model == 'GFS':
             # Full-domain grib directory
 #            grib_dir_full = grib_dir_parent.joinpath('gfs',icbc_cycle_yyyymmdd_hh)
-            grib_dir_full = grib_dir_parent.joinpath(f'gfs.{icbc_cycle_yyyymmdd}.',icbc_cycle_hr,'atmos')
+            grib_dir_full = grib_dir_parent.joinpath(f'gfs.{icbc_cycle_yyyymmdd}',icbc_cycle_hr,'atmos')
 
             # Subsetted-domain grib directory
             grib_dir_subset = grib_dir_parent.joinpath(f'gfs.{icbc_cycle_yyyymmdd}.subset',icbc_cycle_hr,'atmos')


### PR DESCRIPTION
To address #13 an extraneous period was removed from the definition of grib_dir_full when using GFS. This should resolve downstream failures with ungrib.exe.