### PR TITLE
Feature 9 replace utcnow

### DIFF
--- a/download_gefs_from_aws.py
+++ b/download_gefs_from_aws.py
@@ -204,10 +204,10 @@ def main(cycle_dt_str, sim_hrs, members, out_dir_parent, icbc_fc_dt, now_time_be
 
 
 if __name__ == '__main__':
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
     cycle_dt, sim_hrs, members, out_dir_parent, icbc_fc_dt, int_h = parse_args()
     main(cycle_dt, sim_hrs, members, out_dir_parent, icbc_fc_dt, now_time_beg, int_h)
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/download_gefs_from_nomads.py
+++ b/download_gefs_from_nomads.py
@@ -118,10 +118,10 @@ def main(cycle_dt_str, sim_hrs, members, now_time_beg):
 
 
 if __name__ == '__main__':
-	now_time_beg = dt.datetime.utcnow()
+	now_time_beg = dt.datetime.now(dt.UTC)
 	cycle_dt, sim_hrs, members = parse_args()
 	main(cycle_dt, sim_hrs, members, now_time_beg)
-	now_time_end = dt.datetime.utcnow()
+	now_time_end = dt.datetime.now(dt.UTC)
 	run_time_tot = now_time_end - now_time_beg
 	now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
 	now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/download_gfs_from_aws.py
+++ b/download_gfs_from_aws.py
@@ -131,10 +131,10 @@ def main(cycle_dt_str, sim_hrs, out_dir, icbc_fc_dt, resolution, now_time_beg, i
 
 
 if __name__ == '__main__':
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
     cycle_dt, sim_hrs, out_dir, icbc_fc_dt, resolution, int_h = parse_args()
     main(cycle_dt, sim_hrs, out_dir, icbc_fc_dt, resolution, now_time_beg, int_h)
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/run_geogrid.py
+++ b/run_geogrid.py
@@ -150,10 +150,10 @@ def main(wps_dir, run_dir, tmp_dir, nml_tmp, scheduler, hostname):
 
 
 if __name__ == '__main__':
-	now_time_beg = dt.datetime.utcnow()
+	now_time_beg = dt.datetime.now(dt.UTC)
 	wps_dir, run_dir, tmp_dir, nml_tmp, scheduler, hostname = parse_args()
 	main(wps_dir, run_dir, tmp_dir, nml_tmp, scheduler, hostname)
-	now_time_end = dt.datetime.utcnow()
+	now_time_end = dt.datetime.now(dt.UTC)
 	run_time_tot = now_time_end - now_time_beg
 	now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
 	now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/run_metgrid.py
+++ b/run_metgrid.py
@@ -218,10 +218,10 @@ def main(cycle_dt_beg, sim_hrs, wps_dir, run_dir, out_dir, ungrib_dir, tmp_dir, 
 
 
 if __name__ == '__main__':
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
     cycle_dt, sim_hrs, wps_dir, run_dir, out_dir, grib_dir, tmp_dir, icbc_model, nml_tmp, scheduler, hostname = parse_args()
     main(cycle_dt, sim_hrs, wps_dir, run_dir, out_dir, grib_dir, tmp_dir, icbc_model, nml_tmp, scheduler, hostname)
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/run_real.py
+++ b/run_real.py
@@ -242,10 +242,10 @@ def main(cycle_dt_beg, sim_hrs, wrf_dir, run_dir, metgrid_dir, tmp_dir, icbc_mod
 
 
 if __name__ == '__main__':
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
     cycle_dt, sim_hrs, wrf_dir, run_dir, metgrid_dir, tmp_dir, icbc_model, exp_name, nml_tmp, scheduler, hostname = parse_args()
     main(cycle_dt, sim_hrs, wrf_dir, run_dir, metgrid_dir, tmp_dir, icbc_model, exp_name, nml_tmp, scheduler, hostname)
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/run_ungrib.py
+++ b/run_ungrib.py
@@ -476,10 +476,10 @@ def main(cycle_dt_str, sim_hrs, wps_dir, run_dir, out_dir, grib_dir, temp_dir, i
 
 
 if __name__ == '__main__':
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
     cycle_dt, sim_hrs, wps_dir, run_dir, out_dir, grib_dir, temp_dir, icbc_source, icbc_model, int_hrs, icbc_fc_dt, scheduler, mem_id, hostname = parse_args()
     main(cycle_dt, sim_hrs, wps_dir, run_dir, out_dir, grib_dir, temp_dir, icbc_source, icbc_model, int_hrs, icbc_fc_dt, scheduler, mem_id, hostname)
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/run_upp.py
+++ b/run_upp.py
@@ -315,12 +315,12 @@ def fill_tmpl_wildcards(tmpl_path: str, submit_file_path: str, run_upp_script: p
 
 if __name__ == '__main__':
 
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
 
     params = parse_args()
     main(**params)
 
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/run_wrf.py
+++ b/run_wrf.py
@@ -295,10 +295,10 @@ def main(cycle_dt_beg, sim_hrs, wrf_dir, run_dir, tmp_dir, icbc_model, exp_name,
         log.info('   '+str(run_dir))
 
 if __name__ == '__main__':
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
     cycle_dt, sim_hrs, wrf_dir, run_dir, tmp_dir, icbc_model, exp_name, nml_tmp, monitor_wrf, scheduler, hostname = parse_args()
     main(cycle_dt, sim_hrs, wrf_dir, run_dir, tmp_dir, icbc_model, exp_name, nml_tmp, monitor_wrf, scheduler, hostname)
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')

--- a/upp_batch.py
+++ b/upp_batch.py
@@ -361,12 +361,12 @@ def construct_output_path_for_run(root_dir, run_datetime, exp_name, is_working_d
 
 if __name__ == '__main__':
 
-    now_time_beg = dt.datetime.utcnow()
+    now_time_beg = dt.datetime.now(dt.UTC)
 
     params = parse_args()
     main(**params)
 
-    now_time_end = dt.datetime.utcnow()
+    now_time_end = dt.datetime.now(dt.UTC)
     run_time_tot = now_time_end - now_time_beg
     now_time_beg_str = now_time_beg.strftime('%Y-%m-%d %H:%M:%S')
     now_time_end_str = now_time_end.strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Addressing #9. Replaced dt.datetime.utcnow() with dt.datetime.now(dt.UTC) in all files in the repo. This was already tested in a couple of scripts previously embedded with other pull requests, so did not require robust testing of every script modified in this pull request.