### PR TITLE
Bugfix 52 HRRR exp_name namelist template fix

### DIFF
--- a/setup_wps_wrf.py
+++ b/setup_wps_wrf.py
@@ -274,6 +274,15 @@ def main(cycle_dt_str_beg, cycle_dt_str_end, cycle_int_h, sim_hrs, icbc_fc_dt, e
             # namelist.input.hrrr.mem01, namelist.input.gfs.mem02, etc.) & run workflow separately for each icbc_model.
             wrf_nml_tmp = 'namelist.input.' + icbc_model.lower() + '.'+exp_name
 
+            # As above, handle use of HRRR (hybr or pres) when using an exp_name
+            if icbc_model in variants_hrrr:
+                if hrrr_native:
+                    wrf_nml_tmp_hrrr = f'namelist.input.hrrr.hybr.{exp_name}'
+                else:
+                    wrf_nml_tmp_hrrr = f'namelist.input.hrrr.pres.{exp_name}'
+                if template_dir.joinpath(wrf_nml_tmp_hrrr).exists():
+                    wrf_nml_tmp = wrf_nml_tmp_hrrr
+
         # Add some error-checking for the existence of the expected WPS & WRF namelist templates
         if not template_dir.joinpath(wps_nml_tmp).exists():
             log.error('ERROR: Expected WPS namelist template file ' + str(


### PR DESCRIPTION
Small change so when using HRRR and an `exp_name` the expected template namelist file is `namelist.input.hrrr.hybr.{exp_name}` or `namelist.input.hrrr.pres.{exp_name}`

## Expected Differences ##

- [ ] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Verified the correct template WRF namelist file is identified when using `icbc_model = HRRR` and `exp_name = {something}`.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
No additional testing required.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
No documentation updates are required for this.

- [x] Do these changes include sufficient testing updates? **[Yes]**

- [x] Please complete this pull request review by **[Fill in date]**.</br>
21 Aug 2025

## Pull Request Checklist ##
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Select: **Reviewer(s)**
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
