### PR TITLE
Bugfix 49 realtime option

### DIFF
--- a/docs/user_instructions.rst
+++ b/docs/user_instructions.rst
@@ -173,12 +173,13 @@ Main YAML Configuration
      (namelists, wrfout*, logs) into an archival directory (set :code:`arc_dir` to a
      write accessible directory) for easy retrieval. (Default value: :code:`False`.)
 
-   * :code:`realtime`: When :code:`True`, the workflow will hold after submitting WRF
-     and monitor the progress of the WRF job, and not move on to the next step of the
-     workflow or the next model cycle until WRF completes successfully. If :code:`False`,
-     then the workflow will move to the next step or model cycle immediately after
-     submitting WRF to the queue, without waiting to monitor its status, progress, or
-     success. (Default value: :code:`False`.)
+   * :code:`realtime`: When :code:`True` while :code:`run_wrf = True`, the workflow
+     will hold after submitting WRF and monitor the progress of the WRF job, and not
+     move on to the next step of the workflow or the next model cycle until WRF completes
+     successfully. If :code:`realtime = False` while :code:`run_wrf = True`, then the
+     workflow will move to the next step or model cycle immediately after submitting WRF
+     to the queue, without waiting to monitor its status, progress, or success. If
+     :code:`run_wrf = False`, then :code:`realtime` has no effect. (Default value: :code:`False`.)
 
 All other fields can remain at their default values unless specialized
 cases arise.

--- a/docs/user_instructions.rst
+++ b/docs/user_instructions.rst
@@ -173,6 +173,13 @@ Main YAML Configuration
      (namelists, wrfout*, logs) into an archival directory (set :code:`arc_dir` to a
      write accessible directory) for easy retrieval. (Default value: :code:`False`.)
 
+   * :code:`realtime`: When :code:`True`, the workflow will hold after submitting WRF
+     and monitor the progress of the WRF job, and not move on to the next step of the
+     workflow or the next model cycle until WRF completes successfully. If :code:`False`,
+     then the workflow will move to the next step or model cycle immediately after
+     submitting WRF to the queue, without waiting to monitor its status, progress, or
+     success. (Default value: :code:`False`.)
+
 All other fields can remain at their default values unless specialized
 cases arise.
    

--- a/setup_wps_wrf.py
+++ b/setup_wps_wrf.py
@@ -525,12 +525,12 @@ def main(cycle_dt_str_beg, cycle_dt_str_end, cycle_int_h, sim_hrs, icbc_fc_dt, e
 
         if do_wrf:
             cmd_list = ['python', 'run_wrf.py', '-b', cycle_str, '-s', str(sim_hrs), '-w', wrf_ins_dir,
-                        '-r', wrf_run_dir, '-t', template_dir, '-i', icbc_model, '-n', wrf_nml_tmp, '-m',
+                        '-r', wrf_run_dir, '-t', template_dir, '-i', icbc_model, '-n', wrf_nml_tmp,
                         '-q', scheduler, '-a', hostname]
             if exp_name is not None:
                 cmd_list.append('-x')
                 cmd_list.append(exp_name)
-            if do_upp or archive:
+            if do_upp or archive or realtime:
                 cmd_list.append('-m')
             ret, output = exec_command(cmd_list, log)
 


### PR DESCRIPTION
## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Verified that by removing the `-m` option from always being supplied to `run_wrf.py` when called by `setup_wps_wrf.py`, and only supplying it when `realtime = True` while `run_wrf = True`, the workflow cycles around to the next model cycle immediately after submitting WRF when `realtime = False` and `run_wrf = True`. This is the desired behavior that was not working previously. When `realtime = True` and `run_wrf = True`, then the workflow will pause and not advance to the next step or model cycle, which is how the workflow was always behaving prior to this fix, regardless of the value of `realtime`.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
No additional testing required.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[Yes]**

- [ ] Please complete this pull request review by **[1 Oct 2025]**.</br>

## Pull Request Checklist ##
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Select: **Reviewer(s)**
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
