### PR TITLE
Bugfix 66 Preserve constants_name in &metgrid section of namelist.wps

### DIFF
--- a/run_metgrid.py
+++ b/run_metgrid.py
@@ -217,11 +217,11 @@ def main(cycle_dt_beg, sim_hrs, wps_dir, run_dir, out_dir, ungrib_dir, tmp_dir, 
 
             elif line.strip()[0:28] == 'opt_output_from_metgrid_path':
                 out_file.write(" opt_output_from_metgrid_path = '"+str(out_dir)+"',\n")
-            elif line.strip()[0:8] == '&metgrid' and not constants_name:
+            elif line.strip()[0:8] == '&metgrid' and not constants_name and use_tavgsfc:
                 # Add a new line in the &metgrid section since we know from before that constants_name is not present
                 newline = line + " constants_name = '" + str(run_dir) + "/TAVGSFC',\n"
                 out_file.write(newline)
-            elif line.strip()[0:14] == 'constants_name':
+            elif line.strip()[0:14] == 'constants_name' and use_tavgsfc:
                 # Add TAVGSFC to the constants_name line if it isn't already included
                 index = line.find('TAVGSFC')
                 if index == -1:
@@ -229,6 +229,9 @@ def main(cycle_dt_beg, sim_hrs, wps_dir, run_dir, out_dir, ungrib_dir, tmp_dir, 
                     newline = line.split(sep='\n')[0]
                     newline += "'TAVGSFC',\n"
                     out_file.write(newline)
+                else:
+                    # If TAVGSFC is already there, then simply write out the whole line without modification
+                    out_file.write(line)
             else:
                 out_file.write(line)
 


### PR DESCRIPTION
Tweaks to ensure that the constants_name line in the &metgrid section of namelist.wps is preserved and not inadvertently deleted.

## Expected Differences ##

- [ ] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>

## Pull Request Testing ##

- [ ] Describe testing already performed for these changes:</br>
Ensured that `namelist.wps` now contains the `constants_name` line when the template already included `TAVGSFC`. This is the desired behavior.

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
None needed.

- [ ] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[N/A]**

- [ ] Do these changes include sufficient testing updates? **[Yes]**

- [ ] Please complete this pull request review by **[29 Oct 2025]**.</br>

## Pull Request Checklist ##
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Select: **Reviewer(s)**
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
